### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/fc/projectboard/domain/Article.java
+++ b/src/main/java/fc/projectboard/domain/Article.java
@@ -66,11 +66,11 @@ public class Article extends AuditingFields{
         if (!(o instanceof Article that)) return false;
         // [중요] 영속화 되기 전에는 id가 null일 것이다.(영속화 후 id가 넣어지므로) 그러므로 둘이 같은지 비교할때는 null이 아닐때에만 비교해야한다.
         // id가 null이 아닌지 체크 필요.
-        return id != null && id.equals(that.getId()); // 그냥 id가 아니라 getId로 조회 필요
+        return this.getId() != null && this.getId().equals(that.getId()); // 그냥 id가 아니라 getId로 조회 필요
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/fc/projectboard/domain/ArticleComment.java
+++ b/src/main/java/fc/projectboard/domain/ArticleComment.java
@@ -51,11 +51,11 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.getId());
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/fc/projectboard/domain/UserAccount.java
+++ b/src/main/java/fc/projectboard/domain/UserAccount.java
@@ -53,11 +53,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.getUserId());
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
스프링 데이터 JPA로 엔티티를 다룰 때, 엔티티 데이터는 하이버네이트 구현체가 만든 프록시 객체를 이용하여 지연 로딩될 수 있다.
따라서 엔티티를 조회할 때 필드에 직접 접근하면 id == null 인 상황이 있을 수 있고, 이러면 올바른 비교를 하지 못 하게 된다.

getter를 사용하면 이러한 문제를 예방할 수 있다.

- Article
- ArticleComment
- UserAccount

This closes #64 